### PR TITLE
Add support for the upsert option when creating entities

### DIFF
--- a/NGSI.js
+++ b/NGSI.js
@@ -2510,7 +2510,10 @@
 
                 var oldOnFailure = options.onFailure;
                 options.onFailure = function () {
-                    this.ngsi_proxy.closeCallback(proxy_callback.callback_id);
+                    this.ngsi_proxy.closeCallback(proxy_callback.callback_id).catch(function (error) {
+                        // eslint-disable-next-line no-console
+                        console.log("Error closing callback on the ngsi-proxy");
+                    });
                     if (typeof oldOnFailure === 'function') {
                         oldOnFailure.apply(this, arguments);
                     }

--- a/NGSI.js
+++ b/NGSI.js
@@ -2934,6 +2934,10 @@
      * - `keyValues` (`Boolean`; default: `false`): Use flat attributes
      * - `service` (`String`): Service/tenant to use in this operation
      * - `servicepath` (`String`): Service path to use in this operation
+     * - `upsert` (`Boolean`; default: `false`): If `true`, entity is
+     *   updated if already exits. If `upsert` is `false` this operation
+     *   will fail if the entity already exists.
+     *
      *
      * @returns {Promise}
      *
@@ -3004,7 +3008,11 @@
         var connection = privates.get(this);
         var parameters = {};
 
-        if (options.keyValues === true) {
+        if (options.keyValues === true && options.upsert === true) {
+            parameters.options = "keyValues,upsert";
+        } else if (options.upsert === true) {
+            parameters.options = "upsert";
+        } else if (options.keyValues === true) {
             parameters.options = "keyValues";
         }
 
@@ -3020,7 +3028,7 @@
             }
         }).then(function (response) {
             var correlator = response.getHeader('Fiware-correlator');
-            if (response.status !== 201) {
+            if ((options.upsert !== true && response.status !== 201) || (options.upsert === true && [201, 204].indexOf(response.status) === -1)) {
                 return Promise.reject(new NGSI.InvalidResponseError('Unexpected error code: ' + response.status, correlator));
             }
             return Promise.resolve({

--- a/tests/common/v2Spec.js
+++ b/tests/common/v2Spec.js
@@ -499,6 +499,60 @@ if ((typeof require === 'function') && typeof global != null) {
                 });
             });
 
+            it("basic request (using the upsert option)", function (done) {
+                ajaxMockup.addStaticURL("http://ngsi.server.com/v2/entities", {
+                    method: "POST",
+                    status: 201,
+                    headers: {
+                        'Fiware-correlator': 'correlatortoken',
+                        'Location': '/v2/entities/a?type=b'
+                    },
+                    checkRequestContent: function (url, options) {
+                        var data = JSON.parse(options.postBody);
+                        expect(data).toEqual(entity_values);
+                        expect(options.parameters.options).toEqual("upsert");
+                    }
+                });
+
+                connection.v2.createEntity(entity_values, {upsert: true}).then(function (value) {
+                    expect(value).toEqual({
+                        correlator: 'correlatortoken',
+                        entity: entity_values,
+                        location: "/v2/entities/a?type=b"
+                    });
+                    done();
+                }, function (e) {
+                    fail("Failure callback called");
+                });
+            });
+
+            it("basic request (using the upsert and the keyValues options)", function (done) {
+                ajaxMockup.addStaticURL("http://ngsi.server.com/v2/entities", {
+                    method: "POST",
+                    status: 201,
+                    headers: {
+                        'Fiware-correlator': 'correlatortoken',
+                        'Location': '/v2/entities/a?type=b'
+                    },
+                    checkRequestContent: function (url, options) {
+                        var data = JSON.parse(options.postBody);
+                        expect(data).toEqual(entity_values);
+                        expect(options.parameters.options).toEqual("keyValues,upsert");
+                    }
+                });
+
+                connection.v2.createEntity(entity_values, {keyValues: true, upsert: true}).then(function (value) {
+                    expect(value).toEqual({
+                        correlator: 'correlatortoken',
+                        entity: entity_values,
+                        location: "/v2/entities/a?type=b"
+                    });
+                    done();
+                }, function (e) {
+                    fail("Failure callback called");
+                });
+            });
+
             it("unexpected error code", function (done) {
                 ajaxMockup.addStaticURL("http://ngsi.server.com/v2/entities", {
                     method: "POST",


### PR DESCRIPTION
Add support for the upsert option when creating entities that was added to the Orion Context Broker v0.15.0. See the telefonicaid/fiware-orion#3217 ticket for more details.