### PR TITLE
fix: ld.appendEntity / merge-patch not allowed

### DIFF
--- a/NGSI.js
+++ b/NGSI.js
@@ -7275,7 +7275,7 @@
         return makeJSONRequest2.call(connection, url, {
             method: "POST",
             parameters: parameters,
-            contentType: "application/merge-patch+json",
+            contentType: "application/json",
             postBody: changes,
             requestHeaders: headers
         }).then((response) => {


### PR DESCRIPTION
This call returns a 415 from Stellio. It seems like merge-patch cannot be used for `post` request.
It works well with `application/json` instead