### PR TITLE
Correctly check presence of exports

### DIFF
--- a/NGSI.js
+++ b/NGSI.js
@@ -53,7 +53,7 @@
 
     /* Detect Node.js */
     /* istanbul ignore if */
-    if ((typeof require === 'function') && typeof exports != null) {
+    if ((typeof require === 'function') && (typeof exports !== 'undefined')) {
         NGSI = exports;
         var URL = require('whatwg-url').URL;
     } else {


### PR DESCRIPTION
`exports` is checked incorrectly, as typeof won't ever return null. If the variable doesn't exist it will return `"undefined"`.